### PR TITLE
Linux Ad Integration - Enable user customized username and using right home dir.

### DIFF
--- a/nodemanager/core/RemoteExecutor.h
+++ b/nodemanager/core/RemoteExecutor.h
@@ -55,7 +55,7 @@ namespace hpc
                 std::unique_ptr<Reporter<std::vector<unsigned char>>> metricReporter;
 
                 std::map<uint64_t, std::shared_ptr<Process>> processes;
-                std::map<int, std::tuple<std::string, bool, bool, bool, bool, std::string>> jobUsers;
+                std::map<int, std::tuple<std::string, bool, bool, bool, bool, std::string, std::string>> jobUsers;
                 std::map<std::string, std::set<int>> userJobs;
                 pthread_rwlock_t lock;
         };

--- a/nodemanager/scripts/ResolveUserName.sh
+++ b/nodemanager/scripts/ResolveUserName.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+## Introduction:
+## This script is used to compose right runas user for HPC nodemanager to run
+## job with sudo -E -u <composedUserName> <commands>
+##
+## By default, HPC will strip domainName and only use userName passed from
+## HPC Windows HeadNode as runas user, this is intend to support Linux 
+## environment without domain joined.
+##
+## When it's in an Active Directly integrated Linux environment, 
+## it's necessary to compose right runas user with different settings, 
+## such as: 'winbind seperator' set in /etc/samba/smb.conf for Winbind
+## or 're_expression' set in /etc/sssd/sssd.conf for SSSD.
+## to ensure right user is used when HPC run jobs.
+##
+## In this case, we need compose runas user, for example:
+## composedUserName="$domainName.$userName" when Winbind Seperator set to . delimiter
+## or In SSSD, when set re_expression = ((?P<domain>.+)\.(?P<name>[^\\\.@]+$))
+## and echo back the composedUserName.
+
+## Parameters:
+## The 1st parameter passed into this script is the domainName used to submit
+## job through HPC. 
+## The 2nd parameter passed into this script is the userName used to submit
+## job through HPC.
+
+
+[ -z "$1" ] && echo "domainName not specified" && exit 202
+[ -z "$2" ] && echo "userName not specified" && exit 202
+
+domainName="$1"
+userName="$2"
+
+## Examples:
+#composedUserName="$domainName.$userName", when . set as delimiter
+#composedUserName="$domainName\$userName", when \ set as delimiter
+composedUserName="$userName"
+
+## To verify if composedUserName exists, comment out these lines if 
+## Be sure you do compose in the right way.
+maxRetry=3
+while [ $maxRetry -gt 0 ]
+do
+	getent passwd $composedUserName > /dev/null 
+	ec=$?
+	if [ $ec -eq 0 ]
+	then
+		break
+	fi
+	echo "Find no user $composedUserName, error code $ec, retry after .5 seconds"
+	((maxRetry--))
+	sleep .5
+done
+
+if [ $ec -ne 0 ]
+then
+	exit $ec
+fi
+#End of verify, which could be comment out for performance consideration.
+
+#Echo back the composedUserName
+echo "$composedUserName"
+
+exit 0
+

--- a/nodemanager/scripts/ResolveUserName.sh
+++ b/nodemanager/scripts/ResolveUserName.sh
@@ -38,6 +38,7 @@ userName="$2"
 composedUserName="$userName"
 
 ## To verify if composedUserName exists, comment out these lines if 
+## performance is the first priority or it's in non AD integrated environment. 
 ## Be sure you do compose in the right way.
 maxRetry=3
 while [ $maxRetry -gt 0 ]

--- a/nodemanager/test/ProcessTest.cpp
+++ b/nodemanager/test/ProcessTest.cpp
@@ -124,14 +124,18 @@ a8lxTKnZCsRXU1HexqZs+DSc+30tz50bNqLdido/l5B4EJnQP03ciO0=\
 -----END RSA PRIVATE KEY-----";
 
     std::string publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEkoEAGGc6wT16d4Ye+yN2hcqigdTGlMcjUlW6cAmRWYXLwkKoW3WlX3xAK0oQdMLqRDu2PVRPY3qfHURj0EEellpydeaSekp1fg27Rw2VKmEumu6Wxwo9HddXORPAQXTQ4yI0lWSerypckXVPeVjHetbkSci2foLedCbeBA9c/RyRgIUl227/pJKDNX2Rpqly0sY82nVWN/0p4NAyslexA0fGdBx+IgKnbU2JQKJeiwOomtEB/N492XRfCw2eCi7Ly3R8+U1KeBm+zH6Q8aH8ApqQohhLRw71bcWZ1g1bxd6HORxXOu0mFTzHbWFcZ9ILtXRl4Pt0x5Mve1AJXEKb hpclabsa@longhaulLN5-033\n";
-
+	
     int ret = System::CreateUser(userName, password);
     if (ret != 0) return false;
-    ret = System::AddSshKey(userName, privateKey, "id_rsa");
+    
+    std::string userHomeDir; 
+    ret = System::GetHomeDir(userName, userHomeDir);
     if (ret != 0) return false;
-    ret = System::AddSshKey(userName, publicKey, "id_rsa.pub");
+    ret = System::AddSshKey(userName, userHomeDir, privateKey, "id_rsa");
     if (ret != 0) return false;
-    ret = System::AddAuthorizedKey(userName, publicKey);
+    ret = System::AddSshKey(userName, userHomeDir, publicKey, "id_rsa.pub");
+    if (ret != 0) return false;
+    ret = System::AddAuthorizedKey(userHomeDir, publicKey);
     if (ret != 0) return false;
 
     Process p(
@@ -216,11 +220,15 @@ a8lxTKnZCsRXU1HexqZs+DSc+30tz50bNqLdido/l5B4EJnQP03ciO0=\
 
     int ret = System::CreateUser(userName, password);
     if (ret != 0) return false;
-    ret = System::AddSshKey(userName, privateKey, "id_rsa");
+    
+    std::string userHomeDir; 
+    ret = System::GetHomeDir(userName, userHomeDir);
     if (ret != 0) return false;
-    ret = System::AddSshKey(userName, publicKey, "id_rsa.pub");
+    ret = System::AddSshKey(userName, userHomeDir, privateKey, "id_rsa");
     if (ret != 0) return false;
-    ret = System::AddAuthorizedKey(userName, publicKey);
+    ret = System::AddSshKey(userName, userHomeDir, publicKey, "id_rsa.pub");
+    if (ret != 0) return false;
+    ret = System::AddAuthorizedKey(userHomeDir, publicKey);
     if (ret != 0) return false;
 
     Process p(
@@ -305,11 +313,14 @@ a8lxTKnZCsRXU1HexqZs+DSc+30tz50bNqLdido/l5B4EJnQP03ciO0=\
 
     int ret = System::CreateUser(userName, password);
     if (ret != 0) return false;
-    ret = System::AddSshKey(userName, privateKey, "id_rsa");
+    std::string userHomeDir; 
+    ret = System::GetHomeDir(userName, userHomeDir);
     if (ret != 0) return false;
-    ret = System::AddSshKey(userName, publicKey, "id_rsa.pub");
+    ret = System::AddSshKey(userName, userHomeDir, privateKey, "id_rsa");
     if (ret != 0) return false;
-    ret = System::AddAuthorizedKey(userName, publicKey);
+    ret = System::AddSshKey(userName, userHomeDir, publicKey, "id_rsa.pub");
+    if (ret != 0) return false;
+    ret = System::AddAuthorizedKey(userHomeDir, publicKey);
     if (ret != 0) return false;
 
     Process p(

--- a/nodemanager/utils/System.cpp
+++ b/nodemanager/utils/System.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <unistd.h>
 #include <set>
+#include <pwd.h>
 
 #include "System.h"
 #include "String.h"
@@ -404,10 +405,11 @@ int System::CreateUser(
 
 int System::AddSshKey(
     const std::string& userName,
+    const std::string& userHomeDir,
     const std::string& key,
     const std::string& fileName)
 {
-    std::string sshFolder = String::Join("", "/home/", userName, "/.ssh/");
+    std::string sshFolder = String::Join("", userHomeDir, "/.ssh/");
 
     std::string output;
     int ret = System::ExecuteCommandOut(
@@ -445,10 +447,10 @@ int System::AddSshKey(
 }
 
 int System::RemoveSshKey(
-    const std::string& userName,
+    const std::string& userHomeDir,
     const std::string& fileName)
 {
-    std::string sshFolder = String::Join("", "/home/", userName, "/.ssh/");
+    std::string sshFolder = String::Join("", userHomeDir, "/.ssh/");
 
     auto keyFileName = String::Join("", sshFolder, fileName);
     std::ifstream test(keyFileName);
@@ -465,10 +467,10 @@ int System::RemoveSshKey(
 }
 
 int System::AddAuthorizedKey(
-    const std::string& userName,
+    const std::string& userHomeDir,
     const std::string& key)
 {
-    std::string sshFolder = String::Join("", "/home/", userName, "/.ssh/");
+    std::string sshFolder = String::Join("", userHomeDir, "/.ssh/");
 
     std::ofstream authFile(String::Join("", sshFolder, "authorized_keys"), std::ios::app);
 
@@ -486,10 +488,10 @@ int System::AddAuthorizedKey(
 }
 
 int System::RemoveAuthorizedKey(
-    const std::string& userName,
+    const std::string& userHomeDir,
     const std::string& key)
 {
-    std::string sshFolder = String::Join("", "/home/", userName, "/.ssh/");
+    std::string sshFolder = String::Join("", userHomeDir, "/.ssh/");
 
     std::ifstream authFile(String::Join("", sshFolder, "authorized_keys"), std::ios::in);
     std::vector<std::string> lines;
@@ -541,3 +543,69 @@ int System::DeleteUser(const std::string& userName)
 
     return ret;
 }
+
+int System::ResolveUserName(const std::string& domainUserName, std::string& output)
+{
+    int ret = 0;
+    std::string composedUserName = domainUserName;
+	
+    auto userNameTokens = String::Split(composedUserName, '\\');
+    if (userNameTokens.size() > 1)
+    {
+        std::string domainName = userNameTokens[0];
+        std::string userName = userNameTokens[userNameTokens.size() - 1];
+
+        if (userName == "root") 
+        { 
+            composedUserName = "hpc_faked_root"; 
+        }
+        else
+        {
+	        ret = System::ExecuteCommandOut(composedUserName, "/bin/bash", "ResolveUserName.sh", domainName, userName);
+
+            if (ret != 0)
+	        {
+	            Logger::Error("/bin/bash ResolveUserName.sh {0} {1} error code {2} {3}", domainName, userName, ret, composedUserName);
+	        }
+        }
+    }
+
+    output = composedUserName;
+
+    return ret;
+}
+
+int System::TouchHomeDir(const std::string& userName, const std::string& umask)
+{
+    std::string output;
+	
+    int ret = System::ExecuteCommandOut(output, "mkhomedir_helper", userName, umask);
+
+    if (ret != 0)
+    {
+        Logger::Error("mkhomedir_helper {0} {1} error code {2} {3}", userName, umask, ret, output);
+    }
+
+    return ret;
+}
+
+int System::GetHomeDir(const std::string& userName, std::string& output)
+{
+    int ret = 0;
+	
+    struct passwd *result = getpwnam(userName.c_str());
+
+    if (result == NULL || result->pw_dir == NULL)
+    {
+        ret = -1;
+    }
+    else
+    {
+        std::string homeDir(result->pw_dir);
+        output = homeDir;
+    }
+
+    return ret;
+}
+
+

--- a/nodemanager/utils/System.h
+++ b/nodemanager/utils/System.h
@@ -43,22 +43,29 @@ namespace hpc
 
                 static int AddSshKey(
                     const std::string& userName,
+                    const std::string& userHomeDir,
                     const std::string& key,
                     const std::string& fileName);
 
                 static int RemoveSshKey(
-                    const std::string& userName,
+                    const std::string& userHomeDir,
                     const std::string& fileName);
 
                 static int AddAuthorizedKey(
-                    const std::string& userName,
+                    const std::string& userHomeDir,
                     const std::string& key);
 
                 static int RemoveAuthorizedKey(
-                    const std::string& userName,
+                    const std::string& userHomeDir,
                     const std::string& key);
 
                 static int DeleteUser(const std::string& userName);
+
+                static int ResolveUserName(const std::string& domainUserName, std::string& output);
+
+                static int TouchHomeDir(const std::string& userName, const std::string& umask);
+
+                static int GetHomeDir(const std::string& userName, std::string& output);
 
                 template <typename ... Args>
                 static int ExecuteCommandIn(const std::string& input, const std::string& cmd, const Args& ... args)


### PR DESCRIPTION
1. Enable user customize username.
2. Query and use right home dir.
3. Create home dir if user's home dir can be queried out, however missed for some reason, for example run job as an Ad user.
